### PR TITLE
Choose message digest for ECDSA explicitly in tests

### DIFF
--- a/pkg/cosesign1/Makefile.certs
+++ b/pkg/cosesign1/Makefile.certs
@@ -7,18 +7,18 @@ all: chain.pem
 	openssl ec -in $< -pubout -out $@
 
 root.cert.pem: root.private.pem
-	openssl req -new -key $< -out $@.tmp.csr -subj "/CN=Test Root CA (DO NOT TRUST)" -addext 'basicConstraints=critical,CA:TRUE' -addext 'keyUsage=digitalSignature,keyCertSign' 
-	openssl x509 -req -days 365 -in $@.tmp.csr -signkey $< -out $@ -CAcreateserial -extfile cert.extensions.cfg
+	openssl req -new -key $< -out $@.tmp.csr -subj "/CN=Test Root CA (DO NOT TRUST)" -addext 'basicConstraints=critical,CA:TRUE' -addext 'keyUsage=digitalSignature,keyCertSign'
+	openssl x509 -req -sha384 -days 365 -in $@.tmp.csr -signkey $< -out $@ -CAcreateserial -extfile cert.extensions.cfg
 	rm -rf $@.tmp.csr
 
 intermediate.cert.pem: intermediate.private.pem | root.private.pem
-	openssl req -new -key $< -out $@.tmp.csr -subj "/CN=Test Intermediate CA (DO NOT TRUST)" -addext 'basicConstraints=critical,CA:TRUE' -addext 'keyUsage=digitalSignature,keyCertSign' 
-	openssl x509 -req -days 365 -in $@.tmp.csr -CA ${subst private,cert,$|} -CAkey $| -out $@ -CAcreateserial -extfile cert.extensions.cfg
+	openssl req -new -key $< -out $@.tmp.csr -subj "/CN=Test Intermediate CA (DO NOT TRUST)" -addext 'basicConstraints=critical,CA:TRUE' -addext 'keyUsage=digitalSignature,keyCertSign'
+	openssl x509 -req -sha384 -days 365 -in $@.tmp.csr -CA ${subst private,cert,$|} -CAkey $| -out $@ -CAcreateserial -extfile cert.extensions.cfg
 	rm $@.tmp.csr
 
 leaf.cert.pem: leaf.private.pem | intermediate.private.pem
 	openssl req -new -key $< -out $@.tmp.csr -subj "/CN=Test Leaf (DO NOT TRUST)"
-	openssl x509 -req -days 365 -in $@.tmp.csr -CA ${subst private,cert,$|} -CAkey $| -out $@ -CAcreateserial
+	openssl x509 -req -sha384 -days 365 -in $@.tmp.csr -CA ${subst private,cert,$|} -CAkey $| -out $@ -CAcreateserial
 	rm -rf $@.tmp.csr
 
 chain.pem: root.cert.pem intermediate.cert.pem leaf.cert.pem | root.public.pem intermediate.public.pem leaf.public.pem


### PR DESCRIPTION
Some versions of OpenSSL may default to SHA-1 for the `openssl x509 -req` command. (This was the case for me.)

Update Makefile.certs for generate test certificates to specify digest choice explicitly. `SHA2-384`` chosen to match the existing choice of `secp384r1` as the EC params.

Related:
- https://github.com/sigstore/cosign/issues/2091
- https://github.com/golang/go/issues/41682