### PR TITLE
Compile for macos and add binaries to GH releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,16 @@ jobs:
           GOOS: windows
           GOARCH: amd64
           CGO_ENABLED: 0
+      - run: go build -o sign1util-amd64-darwin ./cmd/sign1util
+        env:
+          GOOS: darwin
+          GOARCH: amd64
+          CGO_ENABLED: 0
+      - run: go build -o sign1util-arm64-darwin ./cmd/sign1util
+        env:
+          GOOS: darwin
+          GOARCH: arm64
+          CGO_ENABLED: 0
 
       - uses: actions/upload-artifact@v4
         with:
@@ -36,6 +46,8 @@ jobs:
           path: |
             sign1util.exe
             sign1util
+            sign1util-amd64-darwin
+            sign1util-arm64-darwin
 
   draft_release:
     needs: build
@@ -57,3 +69,5 @@ jobs:
           files: |
             sign1util.exe
             sign1util
+            sign1util-amd64-darwin
+            sign1util-arm64-darwin


### PR DESCRIPTION
Users who want to deploy confidential containers need to use `confcom` extension to compute CCE policy. Confcom extension is relying on `cosesign1go` binaries published in GH. This limits it to be usable only on Windows and Linux as otherwise it fails with the error: `The extension for MacOS has not been implemented.` which originates in:

https://github.com/Azure/azure-cli-extensions/blob/ec58cf6e30f19d6b52a1c46c890c5a014c54ae42/src/confcom/azext_confcom/cose_proxy.py#L78

It would be great to fix it and I propose first starting to build the binaries for MacOS and then incorporate those into the extension so that the customers can use az cli to deploy confidential containers.