### PR TITLE
Validate DID by default in `check` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,23 @@ jobs:
     - name: Build
       run: go build -v ./...
 
+    - name: Diagnose openssl / time / certs
+      run: |
+        set -x
+        date -u
+        timedatectl status || true
+        openssl version -a
+        grep -Ei 'default_days|^days' /etc/ssl/openssl.cnf || true
+        cd pkg/cosesign1
+        make -f Makefile.certs chain.pem
+        date -u
+        for f in root.cert.pem intermediate.cert.pem leaf.cert.pem; do
+          echo "=== $f ==="
+          openssl x509 -in "$f" -noout -subject -issuer -dates -serial
+        done
+        go build ../../cmd/sign1util
+        ./sign1util did-x509 -chain chain.pem -policy cn || true
+
     - name: Test Makafile commands
       run: |
         cd pkg/cosesign1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,23 +24,6 @@ jobs:
     - name: Build
       run: go build -v ./...
 
-    - name: Diagnose openssl / time / certs
-      run: |
-        set -x
-        date -u
-        timedatectl status || true
-        openssl version -a
-        grep -Ei 'default_days|^days' /etc/ssl/openssl.cnf || true
-        cd pkg/cosesign1
-        make -f Makefile.certs chain.pem
-        date -u
-        for f in root.cert.pem intermediate.cert.pem leaf.cert.pem; do
-          echo "=== $f ==="
-          openssl x509 -in "$f" -noout -subject -issuer -dates -serial
-        done
-        go build ../../cmd/sign1util
-        ./sign1util did-x509 -chain chain.pem -policy cn || true
-
     - name: Test Makafile commands
       run: |
         cd pkg/cosesign1

--- a/cmd/sign1util/main.go
+++ b/cmd/sign1util/main.go
@@ -45,15 +45,18 @@ func checkCoseSign1(inputFilename string, chainFilename string, didString string
 	if len(chainPEMString) == 0 {
 		chainPEMString = unpacked.ChainPem
 	}
-	if len(didString) == 0 {
-		didString = unpacked.Issuer
-	}
-	didDoc, err := didx509resolver.Resolve(chainPEMString, didString, true)
-	if err == nil {
-		fmt.Fprintf(os.Stdout, "DID resolvers passed:\n%s\n", didDoc)
-	} else {
-		// all the error paths return an empty string, so we can just print the error
-		fmt.Fprintf(os.Stdout, "DID resolvers failed: err: %s\n", err.Error())
+	// Only resolve when the caller explicitly asked. Callers like `did-x509 -in`,
+	// `leaf -in`, `print -in` pass an empty didString and don't want DID
+	// resolution. The `check` command supplies its own fallback below.
+	if len(didString) > 0 {
+		var didDoc string
+		didDoc, err = didx509resolver.Resolve(chainPEMString, didString, true)
+		if err == nil {
+			fmt.Fprintf(os.Stdout, "DID resolvers passed:\n%s\n", didDoc)
+		} else {
+			// all the error paths return an empty string, so we can just print the error
+			fmt.Fprintf(os.Stdout, "DID resolvers failed: err: %s\n", err.Error())
+		}
 	}
 
 	return unpacked, err
@@ -176,14 +179,22 @@ var checkCmd = cli.Command{
 		},
 	},
 	Action: func(ctx *cli.Context) error {
-		_, err := checkCoseSign1(
+		didString := ctx.String("did")
+		unpacked, err := checkCoseSign1(
 			ctx.String("in"),
 			ctx.String("chain"),
-			ctx.String("did"),
+			didString,
 			ctx.Bool("verbose"),
 		)
 		if err != nil {
 			return fmt.Errorf("failed check: %w", err)
+		}
+		// If no explicit -did was given, validate the issuer embedded in the
+		// COSE document against the chain.
+		if len(didString) == 0 && len(unpacked.Issuer) > 0 {
+			if _, err := didx509resolver.Resolve(unpacked.ChainPem, unpacked.Issuer, true); err != nil {
+				return fmt.Errorf("failed check (issuer from cose %q): %w", unpacked.Issuer, err)
+			}
 		}
 		return nil
 	},

--- a/cmd/sign1util/main.go
+++ b/cmd/sign1util/main.go
@@ -176,7 +176,6 @@ var checkCmd = cli.Command{
 		},
 	},
 	Action: func(ctx *cli.Context) error {
-
 		_, err := checkCoseSign1(
 			ctx.String("in"),
 			ctx.String("chain"),

--- a/cmd/sign1util/main.go
+++ b/cmd/sign1util/main.go
@@ -41,6 +41,20 @@ func checkCoseSign1(inputFilename string, chainFilename string, didString string
 		fmt.Fprintf(os.Stdout, "pubcert: %s\n", unpacked.Pubcert)
 		fmt.Fprintf(os.Stdout, "payload:\n%s\n", string(unpacked.Payload[:]))
 	}
+
+	// Validate DID parsed from the CoseSign1 document.
+	if len(chainPEMString) == 0 {
+		chainPEMString = unpacked.ChainPem
+	}
+	didDoc, err := didx509resolver.Resolve(chainPEMString, unpacked.Issuer, true)
+	if err == nil {
+		fmt.Fprintf(os.Stdout, "DID resolvers passed:\n%s\n", didDoc)
+	} else {
+		// all the error paths return an empty string, so we can just print the error
+		fmt.Fprintf(os.Stdout, "DID resolvers failed: err: %s\n", err.Error())
+	}
+
+	// Validate DID provided as a parameter if provided.
 	if len(didString) > 0 {
 		if len(chainPEMString) == 0 {
 			chainPEMString = unpacked.ChainPem
@@ -173,6 +187,7 @@ var checkCmd = cli.Command{
 		},
 	},
 	Action: func(ctx *cli.Context) error {
+
 		_, err := checkCoseSign1(
 			ctx.String("in"),
 			ctx.String("chain"),

--- a/cmd/sign1util/main.go
+++ b/cmd/sign1util/main.go
@@ -42,11 +42,13 @@ func checkCoseSign1(inputFilename string, chainFilename string, didString string
 		fmt.Fprintf(os.Stdout, "payload:\n%s\n", string(unpacked.Payload[:]))
 	}
 
-	// Validate DID parsed from the CoseSign1 document.
 	if len(chainPEMString) == 0 {
 		chainPEMString = unpacked.ChainPem
 	}
-	didDoc, err := didx509resolver.Resolve(chainPEMString, unpacked.Issuer, true)
+	if len(didString) == 0 {
+		didString = unpacked.Issuer
+	}
+	didDoc, err := didx509resolver.Resolve(chainPEMString, didString, true)
 	if err == nil {
 		fmt.Fprintf(os.Stdout, "DID resolvers passed:\n%s\n", didDoc)
 	} else {
@@ -54,19 +56,6 @@ func checkCoseSign1(inputFilename string, chainFilename string, didString string
 		fmt.Fprintf(os.Stdout, "DID resolvers failed: err: %s\n", err.Error())
 	}
 
-	// Validate DID provided as a parameter if provided.
-	if len(didString) > 0 {
-		if len(chainPEMString) == 0 {
-			chainPEMString = unpacked.ChainPem
-		}
-		didDoc, err := didx509resolver.Resolve(chainPEMString, didString, true)
-		if err == nil {
-			fmt.Fprintf(os.Stdout, "DID resolvers passed:\n%s\n", didDoc)
-		} else {
-			// all the error paths return an empty string, so we can just print the error
-			fmt.Fprintf(os.Stdout, "DID resolvers failed: err: %s\n", err.Error())
-		}
-	}
 	return unpacked, err
 }
 

--- a/pkg/cosesign1/Makefile
+++ b/pkg/cosesign1/Makefile
@@ -24,9 +24,10 @@
 #
 
 
-# note test-fail is expected to fail
-
-AUTOPARSE_CHAIN:=0
+# AUTOPARSE_CHAIN=1 derives ISSUER_DID/DID_FINGERPRINT from chain.pem at recipe time
+# so that `did-check` validates against the actual leaf cert in chain.pem.
+# Set to 0 to fall back to the literal placeholder values below.
+AUTOPARSE_CHAIN:=1
 ISSUER_DID:="TestIssuer"
 FEED:="TestFeed"
 DID_FINGERPRINT:=""
@@ -92,12 +93,14 @@ did-from-cose: sign1util infra.rego.cose
 # note that since the infra.rego.cose is actually good the first part of the check will report a pass "checkCoseSign1 passed"
 
 # expect "DID resolvers failed: err: DID verification failed: unexpected certificate fingerprint"
+# The recipe is expected to fail at the tool level; invert the exit code so the make target succeeds.
 did-fail-fingerprint: chain.pem sign1util infra.rego.cose
-	./sign1util check -in infra.rego.cose -did did:x509:0:sha256:XXXi_nuWegx4NiLaeGabiz36bDUhDDiHEFl8HXMA_4o::subject:CN:Test+Leaf+%28DO+NOT+TRUST%29
+	! ./sign1util check -in infra.rego.cose -did did:x509:0:sha256:XXXi_nuWegx4NiLaeGabiz36bDUhDDiHEFl8HXMA_4o::subject:CN:Test+Leaf+%28DO+NOT+TRUST%29
 
 # expect "DID resolvers failed: err: DID verification failed: invalid subject value: CN=Test XXXX (DO NOT TRUST)"
+# The recipe is expected to fail at the tool level; invert the exit code so the make target succeeds.
 did-fail-subject: chain.pem sign1util infra.rego.cose
-	./sign1util check -in infra.rego.cose -did did:x509:0:sha256:$(DID_FINGERPRINT)::subject:CN:Test+XXXX+%28DO+NOT+TRUST%29
+	! ./sign1util check -in infra.rego.cose -did did:x509:0:sha256:$(DID_FINGERPRINT)::subject:CN:Test+XXXX+%28DO+NOT+TRUST%29
 
 did-fail: did-fail-subject did-fail-fingerprint 
 

--- a/pkg/cosesign1/Makefile
+++ b/pkg/cosesign1/Makefile
@@ -24,13 +24,11 @@
 #
 
 
-# AUTOPARSE_CHAIN=1 derives ISSUER_DID/DID_FINGERPRINT from chain.pem at recipe time
-# so that `did-check` validates against the actual leaf cert in chain.pem.
-# Set to 0 to fall back to the literal placeholder values below.
-AUTOPARSE_CHAIN:=1
+# Opaque label written into the COSE `iss` header. It is NOT validated against
+# the chain at create time; the Go unit test asserts the round-trip preserves
+# this exact string, so don't change it without updating the test.
 ISSUER_DID:="TestIssuer"
 FEED:="TestFeed"
-DID_FINGERPRINT:=""
 
 all: chain.pem cose test-fail test-pass
 
@@ -38,11 +36,6 @@ cose: infra.rego.cose
 
 %.pem:
 	 $(MAKE) -f Makefile.certs chain.pem
-
-ifeq "$(AUTOPARSE_CHAIN)" "1"
-ISSUER_DID = $(shell ./sign1util did-x509 -chain chain.pem -policy cn)
-DID_FINGERPRINT = $(shell ./sign1util did-x509 -chain chain.pem -policy cn | cut -d: -f5)
-endif
 
 # from these media types have to match containerd. The also need to change and the security policy one ought to be x-ms-ccepolicy-frag
 #     fragment atrifact type = application/x-ms-ccepolicy-frag
@@ -75,13 +68,13 @@ show: sign1util
 didx509: chain.pem sign1util
 	./sign1util did-x509 -chain chain.pem -i 1 -policy "subject:CN:Test Leaf (DO NOT TRUST)" -verbose
 
-info: chain.pem sign1util
-	@echo "ISSUER_DID: $(ISSUER_DID)"
-	@echo "DID_FINGERPRINT: $(DID_FINGERPRINT)"
-
-# for this to pass the did:x509 fingerprint (RgpNsHOK5hPlCAfTtiGY_BcDhFRxQbJnhlxNDhxps6U here) needs to be the one output from make print
-did-check: chain.pem infra.rego.cose sign1util info
-	./sign1util check -in infra.rego.cose -did $(ISSUER_DID)
+# did-check derives the REAL did:x509 from chain.pem at run time and resolves
+# it against the chain. Fails loudly if did-x509 returns empty.
+did-check: chain.pem infra.rego.cose sign1util
+	@did="$$(./sign1util did-x509 -chain chain.pem -policy cn)"; \
+	  test -n "$$did" || { echo "did-x509 returned empty - check chain.pem"; exit 1; }; \
+	  echo "did-check: using did=$$did"; \
+	  ./sign1util check -in infra.rego.cose -did "$$did"
 
 # For normal workflow start from the chain.pem, here we'd take the chain from inside the cose sign1 doc, eg to manually confirm it is
 # as otherwise expected (ie that the issuer DID matches the chain) or to shortcut getting a DID from a cose document.
@@ -98,9 +91,13 @@ did-fail-fingerprint: chain.pem sign1util infra.rego.cose
 	! ./sign1util check -in infra.rego.cose -did did:x509:0:sha256:XXXi_nuWegx4NiLaeGabiz36bDUhDDiHEFl8HXMA_4o::subject:CN:Test+Leaf+%28DO+NOT+TRUST%29
 
 # expect "DID resolvers failed: err: DID verification failed: invalid subject value: CN=Test XXXX (DO NOT TRUST)"
-# The recipe is expected to fail at the tool level; invert the exit code so the make target succeeds.
+# Builds a DID with the REAL fingerprint but a WRONG subject; recipe must still
+# fail at the tool level - `!` inverts that into a make-level success.
 did-fail-subject: chain.pem sign1util infra.rego.cose
-	! ./sign1util check -in infra.rego.cose -did did:x509:0:sha256:$(DID_FINGERPRINT)::subject:CN:Test+XXXX+%28DO+NOT+TRUST%29
+	@fp="$$(./sign1util did-x509 -chain chain.pem -policy cn | cut -d: -f5)"; \
+	  test -n "$$fp" || { echo "could not derive fingerprint - check chain.pem"; exit 1; }; \
+	  ! ./sign1util check -in infra.rego.cose \
+	      -did "did:x509:0:sha256:$$fp::subject:CN:Test+XXXX+%28DO+NOT+TRUST%29"
 
 did-fail: did-fail-subject did-fail-fingerprint 
 

--- a/pkg/cosesign1/Makefile.certs
+++ b/pkg/cosesign1/Makefile.certs
@@ -8,12 +8,12 @@ all: chain.pem
 
 root.cert.pem: root.private.pem
 	openssl req -new -key $< -out $@.tmp.csr -subj "/CN=Test Root CA (DO NOT TRUST)" -addext 'basicConstraints=critical,CA:TRUE' -addext 'keyUsage=digitalSignature,keyCertSign' 
-	openssl x509 -req -days 365 -in $@.tmp.csr -signkey $< -out $@ -CAcreateserial -extfile cert.extensions.cfg
+	openssl x509 -req -days 3650 -in $@.tmp.csr -signkey $< -out $@ -CAcreateserial -extfile cert.extensions.cfg
 	rm -rf $@.tmp.csr
 
 intermediate.cert.pem: intermediate.private.pem | root.private.pem
 	openssl req -new -key $< -out $@.tmp.csr -subj "/CN=Test Intermediate CA (DO NOT TRUST)" -addext 'basicConstraints=critical,CA:TRUE' -addext 'keyUsage=digitalSignature,keyCertSign' 
-	openssl x509 -req -days 365 -in $@.tmp.csr -CA ${subst private,cert,$|} -CAkey $| -out $@ -CAcreateserial -extfile cert.extensions.cfg
+	openssl x509 -req -days 1825 -in $@.tmp.csr -CA ${subst private,cert,$|} -CAkey $| -out $@ -CAcreateserial -extfile cert.extensions.cfg
 	rm $@.tmp.csr
 
 leaf.cert.pem: leaf.private.pem | intermediate.private.pem


### PR DESCRIPTION
### Summary

Make `sign1util check` automatically validate the embedded `iss` against the cert chain when `--did` is omitted, fix a swallowed-error bug in the resolver path, and stabilise the Makefile tests.

### Changes

- **`cmd/sign1util/main.go`**
  - `check`: if `--did` is not provided, resolve the COSE document's own `iss` against the embedded chain and return any resolver error to the caller.
  - Fix `:=` shadowing in `checkCoseSign1` that previously dropped `Resolve` errors.
  - Scope DID resolution in `checkCoseSign1` to callers that actually pass a `didString`, so unrelated commands (`print`, `leaf`, `did-x509 -in`) don't perform unwanted DID resolution.
- **`pkg/cosesign1/Makefile`**
  - Recipes that need a real DID (`did-check`, `did-fail-subject`) now derive it inline from `chain.pem` at recipe time. The previously-introduced `AUTOPARSE_CHAIN` toggle and shared `ISSUER_DID` variable are removed — they conflated the COSE `iss` label (a literal asserted by the unit test) with a verifiable DID.
  - Negative tests (`did-fail-*`) invert the expected non-zero exit with `!` so the make target succeeds on a tool-level failure.
- **`pkg/cosesign1/Makefile.certs`**
  - Bump CA validity (root 3650d, intermediate 1825d, leaf 365d) to work around an upstream TODO in `didx509go` (`CurrentTime: chain[0].NotAfter`, see `pkg/did-x509-resolver/resolver.go:36` TODO https://github.com/microsoft/didx509go/blob/main/pkg/did-x509-resolver/resolver.go#L36) that caused intermittent 1-second "current time after notAfter" CI failures when cert generation crossed a wall-clock second boundary. Failure example before the fix: https://github.com/microsoft/cosesign1go/actions/runs/26151406837/job/76919529317

### Tests

`make all` and `go test ./...` pass locally.
